### PR TITLE
Support Cython 3.0

### DIFF
--- a/src/aiolo/abstractservers.pxd
+++ b/src/aiolo/abstractservers.pxd
@@ -34,4 +34,4 @@ cdef int router(
     int argc,
     lo.lo_message raw_msg,
     void *_route
-) nogil except 1
+) except 1 nogil

--- a/src/aiolo/abstractservers.pyx
+++ b/src/aiolo/abstractservers.pyx
@@ -64,7 +64,7 @@ cdef class AbstractServer:
         url: Union[str],
         port: Union[str, int, None],
         proto: Union[str, int, None],
-        multicast: multicasts.MultiCast,
+        multicast: Union[multicasts.MultiCast, None],
     ):
         if self.running:
             raise ValueError('Cannot update server vars while server is running')
@@ -342,7 +342,7 @@ cdef int router(
     int argc,
     lo.lo_message raw_msg,
     void *_server
-) nogil except 1:
+) except 1 nogil:
     cdef int retval = 0
     cdef lo.lo_timetag lo_timetag
     with gil:

--- a/src/aiolo/abstractspecs.pxd
+++ b/src/aiolo/abstractspecs.pxd
@@ -7,7 +7,7 @@ import array
 
 cdef class AbstractSpec:
     IF PYPY:
-        cpdef public object array
+        cdef public object array
     ELSE:
-        cpdef public array.array array
-    cpdef public bint none
+        cdef public array.array array
+    cdef public bint none

--- a/src/aiolo/abstractspecs.pyx
+++ b/src/aiolo/abstractspecs.pyx
@@ -88,6 +88,3 @@ cdef class AbstractSpec:
 
     def __bool__(self):
         return bool(self.array)
-
-    def __len__(self):
-        return len(self.array)

--- a/src/aiolo/addresses.pyx
+++ b/src/aiolo/addresses.pyx
@@ -128,7 +128,7 @@ cdef class Address:
 
     @property
     def interface(self):
-        cdef char * iface = lo.lo_address_get_iface(self.lo_address)
+        cdef const char * iface = lo.lo_address_get_iface(self.lo_address)
         if iface is NULL:
             return None
         return (<bytes>iface).decode('utf8')

--- a/src/aiolo/lo.pxd
+++ b/src/aiolo/lo.pxd
@@ -73,7 +73,7 @@ cdef extern from "lo/lo.h" nogil:
 
     ctypedef void* lo_server_thread
 
-    ctypedef void (*lo_err_handler)(int num, char* msg, char* where)
+    ctypedef void (*lo_err_handler)(int num, const char* msg, const char* where) except *
 
     ctypedef int (*lo_method_handler)(char* path, char* types, lo_arg** argv, int argc, lo_message msg, void* user_data)
 
@@ -81,9 +81,9 @@ cdef extern from "lo/lo.h" nogil:
 
     ctypedef int (*lo_bundle_end_handler)(void* user_data)
 
-    ctypedef int (*lo_server_thread_init_callback)(lo_server_thread s, void* user_data)
+    ctypedef int (*lo_server_thread_init_callback)(lo_server_thread s, void* user_data) except? -1
 
-    ctypedef void (*lo_server_thread_cleanup_callback)(lo_server_thread s, void* user_data)
+    ctypedef void (*lo_server_thread_cleanup_callback)(lo_server_thread s, void* user_data) except *
 
     ctypedef long double lo_hires
 
@@ -251,8 +251,6 @@ cdef extern from "lo/lo.h" nogil:
 
     int lo_server_events_pending(lo_server s)
 
-    void lo_server_set_error_context(lo_server s, void *user_data)
-
     double lo_server_next_event_delay(lo_server s)
 
     int lo_server_max_msg_size(lo_server s, int req_size)
@@ -372,6 +370,11 @@ cdef extern from "lo/lo.h" nogil:
         int lo_servers_wait(lo_server* s, int* status, int num_servers, int timeout)
 
         int lo_servers_recv_noblock(lo_server* s, int* recvd, int num_servers, int timeout)
+
+
+cdef extern from "lo/lo_throw.h" nogil:
+
+    void lo_server_set_error_context(lo_server s, void *user_data)
 
 
 ctypedef struct lo_address_header:

--- a/src/aiolo/pack.pyx
+++ b/src/aiolo/pack.pyx
@@ -14,7 +14,7 @@ from libc.stdint cimport \
     UINT8_MAX as _UINT8_MAX, \
     INT32_MIN as _INT32_MIN, \
     INT32_MAX as _INT32_MAX, \
-    INT64_MAX as _INT64_MIN, \
+    INT64_MIN as _INT64_MIN, \
     INT64_MAX as _INT64_MAX
 
 from libc.stdlib cimport malloc, free
@@ -28,9 +28,9 @@ __all__ = ['UINT8_MAX', 'INT32_MIN', 'INT32_MAX', 'INT64_MIN', 'INT64_MAX', 'INF
 
 
 UINT8_MAX = _UINT8_MAX
-INT32_MIN = -_INT32_MIN # Why is this not negative in the first place?
+INT32_MIN = _INT32_MIN
 INT32_MAX = _INT32_MAX
-INT64_MIN = -_INT64_MIN # Why is this not negative in the first place?
+INT64_MIN = _INT64_MIN
 INT64_MAX = _INT64_MAX
 
 TYPES_CHAR = (str, int)

--- a/src/aiolo/paths.pxd
+++ b/src/aiolo/paths.pxd
@@ -4,7 +4,7 @@ from . cimport abstractspecs
 
 
 cdef class Path(abstractspecs.AbstractSpec):
-    cpdef public object pattern
+    cdef public object pattern
 
 
-cpdef Path _ANY_PATH
+cdef Path _ANY_PATH

--- a/src/aiolo/paths.pyx
+++ b/src/aiolo/paths.pyx
@@ -100,5 +100,5 @@ cdef class Path(abstractspecs.AbstractSpec):
         return self.matches_any or patterns.is_osc_address_pattern(self.as_str)
 
 
-cpdef Path _ANY_PATH = Path(None)
+cdef Path _ANY_PATH = Path(None)
 ANY_PATH = _ANY_PATH

--- a/src/aiolo/typespecs.pxd
+++ b/src/aiolo/typespecs.pxd
@@ -11,36 +11,36 @@ from . import types
 from . cimport abstractspecs
 
 # 32 bit signed integer.
-cpdef char LO_INT32
+cdef char LO_INT32
 # 32 bit IEEE-754 float.
-cpdef char LO_FLOAT
+cdef char LO_FLOAT
 # Standard C, NULL terminated string.
-cpdef char LO_STRING
+cdef char LO_STRING
 # OSC binary blob type. Accessed using the lo_blob_*() functions.
-cpdef char LO_BLOB
+cdef char LO_BLOB
 
 # extended OSC types
 # 64 bit signed integer.
-cpdef char LO_INT64
+cdef char LO_INT64
 # OSC TimeTag type, represented by the lo_timetag structure.
-cpdef char LO_TIMETAG
+cdef char LO_TIMETAG
 # 64 bit IEEE-754 double.
-cpdef char LO_DOUBLE
+cdef char LO_DOUBLE
 # Standard C, NULL terminated, string. Used in systems which
 # distinguish strings and symbols.
-cpdef char LO_SYMBOL
+cdef char LO_SYMBOL
 # Standard C, 8 bit, char variable.
-cpdef char LO_CHAR
+cdef char LO_CHAR
 # A 4 byte MIDI packet.
-cpdef char LO_MIDI
+cdef char LO_MIDI
 # Symbol representing the value True.
-cpdef char LO_TRUE
+cdef char LO_TRUE
 # Symbol representing the value False.
-cpdef char LO_FALSE
+cdef char LO_FALSE
 # Symbol representing the value Nil.
-cpdef char LO_NIL
+cdef char LO_NIL
 # Symbol representing the value Infinitum.
-cpdef char LO_INFINITUM
+cdef char LO_INFINITUM
 
 IF PYPY:
     cdef object ARGTYPES
@@ -67,5 +67,5 @@ cpdef bint flatten_typespec_into(
 
 cpdef bint flatten_args_into(object data: Iterable, list into: List) except 0
 
-cpdef TypeSpec _ANY_ARGS
-cpdef TypeSpec _NO_ARGS
+cdef TypeSpec _ANY_ARGS
+cdef TypeSpec _NO_ARGS

--- a/src/aiolo/typespecs.pyx
+++ b/src/aiolo/typespecs.pyx
@@ -24,61 +24,61 @@ __all__ = [
 # basic OSC types
 # 32 bit signed integer.
 INT32  = 'i'
-cpdef char LO_INT32 = ord(INT32)
+cdef char LO_INT32 = ord(INT32)
 
 # 32 bit IEEE-754 float.
 FLOAT  = 'f'
-cpdef char LO_FLOAT = ord(FLOAT)
+cdef char LO_FLOAT = ord(FLOAT)
 
 # Standard C, NULL terminated string.
 STRING  = 's'
-cpdef char LO_STRING = ord(STRING)
+cdef char LO_STRING = ord(STRING)
 
 # OSC binary blob type. Accessed using the lo_blob_*() functions.
 BLOB  = 'b'
-cpdef char LO_BLOB = ord(BLOB)
+cdef char LO_BLOB = ord(BLOB)
 
 # extended OSC types
 # 64 bit signed integer.
 INT64  = 'h'
-cpdef char LO_INT64 = ord(INT64)
+cdef char LO_INT64 = ord(INT64)
 
 # OSC TimeTag type, represented by the lo_timetag structure.
 TIMETAG  = 't'
-cpdef char LO_TIMETAG = ord(TIMETAG)
+cdef char LO_TIMETAG = ord(TIMETAG)
 
 # 64 bit IEEE-754 double.
 DOUBLE  = 'd'
-cpdef char LO_DOUBLE = ord(DOUBLE)
+cdef char LO_DOUBLE = ord(DOUBLE)
 
 # Standard C, NULL terminated, string. Used in systems which
 # distinguish strings and symbols.
 SYMBOL  = 'S'
-cpdef char LO_SYMBOL = ord(SYMBOL)
+cdef char LO_SYMBOL = ord(SYMBOL)
 
 # Standard C, 8 bit, char variable.
 CHAR  = 'c'
-cpdef char LO_CHAR = ord(CHAR)
+cdef char LO_CHAR = ord(CHAR)
 
 # A 4 byte MIDI packet.
 MIDI  = 'm'
-cpdef char LO_MIDI = ord(MIDI)
+cdef char LO_MIDI = ord(MIDI)
 
 # Symbol representing the value True.
 TRUE  = 'T'
-cpdef char LO_TRUE = ord(TRUE)
+cdef char LO_TRUE = ord(TRUE)
 
 # Symbol representing the value False.
 FALSE  = 'F'
-cpdef char LO_FALSE = ord(FALSE)
+cdef char LO_FALSE = ord(FALSE)
 
 # Symbol representing the value Nil.
 NIL  = 'N'
-cpdef char LO_NIL = ord(NIL)
+cdef char LO_NIL = ord(NIL)
 
 # Symbol representing the value Infinitum.
 INFINITUM  = 'I'
-cpdef char LO_INFINITUM = ord(INFINITUM)
+cdef char LO_INFINITUM = ord(INFINITUM)
 
 
 IF not PYPY:
@@ -183,7 +183,7 @@ cdef class TypeSpec(abstractspecs.AbstractSpec):
                and self.matches_any == other.matches_any \
                and self.matches_no == other.matches_no
 
-    def __lt__(self, other: 'TypeSpec') -> bool:
+    def __lt__(self, other: TypeSpec) -> bool:
         if isinstance(other, str):
             return self.as_str < other
         elif self.matches_any:
@@ -310,7 +310,7 @@ cpdef bint flatten_args_into(object data: Iterable, list into: List) except 0:
     return True
 
 
-cpdef TypeSpec _ANY_ARGS = TypeSpec(None)
-cpdef TypeSpec _NO_ARGS = TypeSpec('')
+cdef TypeSpec _ANY_ARGS = TypeSpec(None)
+cdef TypeSpec _NO_ARGS = TypeSpec('')
 ANY_ARGS = _ANY_ARGS
 NO_ARGS = _NO_ARGS


### PR DESCRIPTION
Fixes errors and warnings when building against Cython 3.0, except the deprecation of "IF". Of special attention, I reverted the workaround for "INT32_MIN" and "INT64_MIN" in "src/aiolo/pack.pyx". I believe the original issue was due to a typo in the "libc.stdint" imports.